### PR TITLE
Display remaining cycles instead of time

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,4 @@ NEXT_PUBLIC_API_URL=https://api.ghostnet.tzkt.io/v1/accounts/
 NEXT_PUBLIC_DELEGATE_ADDRESS=tz1PZY3tEWmXGasYeehXYqwXuw2Z3iZ6QDnA
 NEXT_PUBLIC_TZKT_API_URL=https://api.ghostnet.tzkt.io
 NEXT_PUBLIC_TZKT_UI_URL=https://ghostnet.tzkt.io
+NEXT_PUBLIC_NUM_CYCLES_TO_FINALIZE_AFTER_UNSTAKE=4

--- a/components/AccountBody.tsx
+++ b/components/AccountBody.tsx
@@ -181,7 +181,7 @@ export const AccountBody = ({
               ) : (
                 <ChakraLink
                   as={Link}
-                  href='$(process.env.NEXT_PUBLIC_TZKT_UI_URL)/bakers'
+                  href={`${process.env.NEXT_PUBLIC_TZKT_UI_URL}/bakers`}
                   target='_blank'
                   display='flex'
                   alignItems='center'

--- a/components/Operations/tezInterfaces.ts
+++ b/components/Operations/tezInterfaces.ts
@@ -71,7 +71,7 @@ export interface UnstakedOperation {
   lastLevel: number
   lastTime: string
   remainingFinalizableAmount: number
-  timeToFinalizeInSec: number
+  numCyclesToFinalize: number
 }
 
 export interface BlockchainHead {

--- a/components/operationModals/FinalizeUnstake/PendingUnstakeSection.tsx
+++ b/components/operationModals/FinalizeUnstake/PendingUnstakeSection.tsx
@@ -35,7 +35,7 @@ export const PendingUnstakeSection = ({
 
         {/* Remaining finalizable amount */}
         {unstOps
-          .filter(op => op.timeToFinalizeInSec > 0)
+          .filter(op => op.numCyclesToFinalize > 0)
           .map((op, index) => (
             <UnstakeOperationBox key={index} unstakeOp={op} />
           ))}

--- a/components/operationModals/FinalizeUnstake/UnstakeOperationBox.tsx
+++ b/components/operationModals/FinalizeUnstake/UnstakeOperationBox.tsx
@@ -17,7 +17,7 @@ export const UnstakeOperationBox = ({
 
   let amount = 0
   let requestedTime = ''
-  let timeRemainingInHour = 0
+  let cyclesRemaining = 0
   let canFinalize = false
 
   if (!!totalFinalizableAmount) {
@@ -28,7 +28,7 @@ export const UnstakeOperationBox = ({
   if (!!unstakeOp) {
     amount = mutezToTez(unstakeOp.remainingFinalizableAmount)
     requestedTime = format(parseISO(unstakeOp.firstTime), 'dd MMMM yyyy')
-    timeRemainingInHour = secondsToHours(unstakeOp.timeToFinalizeInSec)
+    cyclesRemaining = unstakeOp.numCyclesToFinalize
   }
 
   return (
@@ -61,11 +61,7 @@ export const UnstakeOperationBox = ({
             </Text>
             <Flex alignItems='center'>
               <Text fontSize='14px' color='#4A5568' fontStyle='italic'>
-                Awaiting next cycle in{' '}
-                {timeRemainingInHour > 24
-                  ? `${Math.round(timeRemainingInHour / 24)} days`
-                  : `${timeRemainingInHour} hours`}{' '}
-                days
+                Awaiting finalization in {cyclesRemaining} cycles
               </Text>
               <Image
                 src='/images/MdOutlineHourglassTop.svg'


### PR DESCRIPTION
Remaining time to finalize is dependent on block time which is variable. Thus changing to remaining cycles which users can see on TZKT. 
fixes #17 