### PR TITLE
tez-164: fix stake workflow

### DIFF
--- a/components/operationModals/Delegate/ConfirmBaker.tsx
+++ b/components/operationModals/Delegate/ConfirmBaker.tsx
@@ -162,9 +162,9 @@ export const ConfirmBaker = ({
                     GACategory.START_DELEGATE_END
                   )
                 }
+                setSuccess(true) // dont show success modal if opened from start earning
               }
               setOpHash(response.opHash)
-              setSuccess(true)
               handleOneStepForward()
             }
           } else {


### PR DESCRIPTION
To fix stake workflow when users stake from begining - won't show success modal when select baker
[ticket](https://linear.app/tezos/issue/TEZ-164/fix-select-amount-work-flow)