### PR TITLE
Sta-33: add learn more button

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -117,6 +117,21 @@ export default function Hero() {
                 >
                   Start Earning
                 </CustomButton>
+                <CustomButton
+                  scrollPadding={80}
+                  scrollMarginBottom={70}
+                  w={['full', null, '180px']}
+                  onClick={() => {
+                    trackGAEvent(GAAction.BUTTON_CLICK, GACategory.LEARN_MORE)
+                    window.open(
+                      'https://docs.tezos.com/using/staking',
+                      '_blank'
+                    )
+                  }}
+                  variant='primary'
+                >
+                  Learn More
+                </CustomButton>
               </Flex>
               <Separator
                 pt={5}

--- a/utils/trackGAEvent.ts
+++ b/utils/trackGAEvent.ts
@@ -37,7 +37,9 @@ export enum GACategory {
   END_STAKE_END = 'end_stake_end',
 
   FINALIZE_BEGIN = 'finalize_begin',
-  FINALIZE_END = 'finalize_end'
+  FINALIZE_END = 'finalize_end',
+
+  LEARN_MORE = 'learn_more'
 }
 
 export const trackGAEvent = (action: GAAction, category: GACategory) => {


### PR DESCRIPTION
On the homepage of the staking app: stake.tezos.com
- Add a button next to 'Start Earning' called 'Learn More'. Use the same UI. 
- It should link to: https://docs.tezos.com/using/staking
[ticket](https://linear.app/tezos/issue/STA-33/link-to-in-depth-tutorial-in-staking-dapp)