### PR TITLE
Fix/safari beacon stale connection

### DIFF
--- a/.env-ghostnet
+++ b/.env-ghostnet
@@ -5,3 +5,6 @@ NEXT_PUBLIC_TZKT_UI_URL=https://ghostnet.tzkt.io
 NEXT_PUBLIC_TZKT_AVATARS_URL=https://services.tzkt.io/v1/avatars
 NEXT_PUBLIC_CONSENSUS_RIGHTS_DELAY=3
 NEXT_PUBLIC_SITE_URL=https://stake-ghostnet.tezos.com
+# Beacon connection debug panel. "true" to show it; anything else (or unset) = off.
+# Can also be toggled at runtime with ?beaconDebug=1 / ?beaconDebug=0.
+NEXT_PUBLIC_BEACON_DEBUG=false

--- a/.env-ghostnet
+++ b/.env-ghostnet
@@ -6,5 +6,4 @@ NEXT_PUBLIC_TZKT_AVATARS_URL=https://services.tzkt.io/v1/avatars
 NEXT_PUBLIC_CONSENSUS_RIGHTS_DELAY=3
 NEXT_PUBLIC_SITE_URL=https://stake-ghostnet.tezos.com
 # Beacon connection debug panel. "true" to show it; anything else (or unset) = off.
-# Can also be toggled at runtime with ?beaconDebug=1 / ?beaconDebug=0.
 NEXT_PUBLIC_BEACON_DEBUG=false

--- a/.env-mainnet
+++ b/.env-mainnet
@@ -5,3 +5,6 @@ NEXT_PUBLIC_TZKT_UI_URL=https://tzkt.io
 NEXT_PUBLIC_TZKT_AVATARS_URL=https://services.tzkt.io/v1/avatars
 NEXT_PUBLIC_CONSENSUS_RIGHTS_DELAY=2
 NEXT_PUBLIC_SITE_URL=https://stake.tezos.com
+# Beacon connection debug panel. "true" to show it; anything else (or unset) = off.
+# Can also be toggled at runtime with ?beaconDebug=1 / ?beaconDebug=0.
+NEXT_PUBLIC_BEACON_DEBUG=false

--- a/.env-mainnet
+++ b/.env-mainnet
@@ -6,5 +6,4 @@ NEXT_PUBLIC_TZKT_AVATARS_URL=https://services.tzkt.io/v1/avatars
 NEXT_PUBLIC_CONSENSUS_RIGHTS_DELAY=2
 NEXT_PUBLIC_SITE_URL=https://stake.tezos.com
 # Beacon connection debug panel. "true" to show it; anything else (or unset) = off.
-# Can also be toggled at runtime with ?beaconDebug=1 / ?beaconDebug=0.
 NEXT_PUBLIC_BEACON_DEBUG=false

--- a/components/BeaconDebugPanel.tsx
+++ b/components/BeaconDebugPanel.tsx
@@ -1,0 +1,228 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Box, Button, Flex, Text } from '@chakra-ui/react'
+import { useConnection } from '@/providers/ConnectionProvider'
+import { resetBeaconWallet } from '@/providers/ConnectionProvider/beacon'
+import {
+  clearAllBeaconStorage,
+  listBeaconStorage,
+  listIndexedDbDatabases,
+  simulateItpEviction,
+  StorageEntry
+} from '@/utils/beaconDebug'
+
+const FLAG_KEY = 'beaconDebug'
+
+// Enabled in dev automatically, or on any build by visiting `?beaconDebug=1`
+// (persisted to localStorage). `?beaconDebug=0` turns it back off. This lets us
+// reproduce the Safari failure on a real deployed URL where ITP actually runs.
+const useDebugEnabled = () => {
+  const [enabled, setEnabled] = useState(false)
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const param = params.get(FLAG_KEY)
+    if (param === '1') localStorage.setItem(FLAG_KEY, '1')
+    if (param === '0') localStorage.removeItem(FLAG_KEY)
+    setEnabled(
+      process.env.NODE_ENV !== 'production' ||
+        localStorage.getItem(FLAG_KEY) === '1'
+    )
+  }, [])
+  return enabled
+}
+
+export const BeaconDebugPanel = () => {
+  const enabled = useDebugEnabled()
+  const { isConnected, address, disconnect } = useConnection()
+  const [entries, setEntries] = useState<StorageEntry[]>([])
+  const [dbs, setDbs] = useState<string[]>([])
+  const [log, setLog] = useState<string>('')
+  const [open, setOpen] = useState(true)
+  const [busy, setBusy] = useState(false)
+
+  const refresh = useCallback(async () => {
+    setEntries(listBeaconStorage())
+    setDbs(await listIndexedDbDatabases())
+  }, [])
+
+  useEffect(() => {
+    if (enabled) refresh()
+  }, [enabled, refresh])
+
+  if (!enabled) return null
+
+  const run = async (label: string, fn: () => Promise<string>) => {
+    setBusy(true)
+    setLog(`${label}…`)
+    try {
+      setLog(await fn())
+    } catch (error) {
+      setLog(`${label} failed: ${String(error)}`)
+    } finally {
+      await refresh()
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Box
+      position='fixed'
+      bottom='12px'
+      right='12px'
+      zIndex={99999}
+      w={open ? '360px' : 'auto'}
+      maxH='70vh'
+      overflowY='auto'
+      bg='#111'
+      color='#eee'
+      borderRadius='10px'
+      border='1px solid #333'
+      fontSize='12px'
+      fontFamily='monospace'
+      boxShadow='0 8px 24px rgba(0,0,0,0.4)'
+      p='10px'
+    >
+      <Flex justify='space-between' align='center' mb={open ? '8px' : '0'}>
+        <Text fontWeight={700}>🔌 Beacon debug</Text>
+        <Button
+          size='xs'
+          variant='outline'
+          color='#eee'
+          borderColor='#444'
+          onClick={() => setOpen(o => !o)}
+        >
+          {open ? 'hide' : 'show'}
+        </Button>
+      </Flex>
+
+      {open && (
+        <>
+          <Box mb='8px'>
+            <Text>
+              app state:{' '}
+              <Text as='span' color={isConnected ? '#5f5' : '#f77'}>
+                {isConnected === undefined
+                  ? 'initializing'
+                  : isConnected
+                    ? 'connected'
+                    : 'disconnected'}
+              </Text>
+            </Text>
+            <Text color='#aaa' wordBreak='break-all'>
+              {address ?? '(no address)'}
+            </Text>
+          </Box>
+
+          <Flex direction='column' gap='6px' mb='8px'>
+            <Button
+              size='xs'
+              bg='#a33'
+              color='white'
+              disabled={busy}
+              onClick={() =>
+                run('Simulate ITP eviction', async () => {
+                  const r = await simulateItpEviction()
+                  return `Removed ${r.removedKeys.length} transport keys + ${r.removedDatabases.length} IndexedDB db(s); kept ${r.keptKeys.length} identity keys. Now reload — with the fix the app should recover to "disconnected" within ~12s instead of hanging.`
+                })
+              }
+            >
+              Simulate ITP eviction (dead transport)
+            </Button>
+
+            <Button
+              size='xs'
+              bg='#933'
+              color='white'
+              disabled={busy}
+              onClick={() =>
+                run('Clear all beacon storage', async () => {
+                  const r = await clearAllBeaconStorage()
+                  return `Cleared ${r.removedKeys.length} keys + ${r.removedDatabases.length} db(s). Equivalent to a manual "clear site data".`
+                })
+              }
+            >
+              Clear ALL beacon storage (baseline)
+            </Button>
+
+            <Button
+              size='xs'
+              bg='#357'
+              color='white'
+              disabled={busy}
+              onClick={() =>
+                run('App disconnect()', async () => {
+                  await disconnect()
+                  return 'Called the app\'s disconnect(). Storage below should now be empty of transport/peer/seed keys.'
+                })
+              }
+            >
+              Test app disconnect() (commit 1)
+            </Button>
+
+            <Button
+              size='xs'
+              bg='#357'
+              color='white'
+              disabled={busy}
+              onClick={() =>
+                run('resetBeaconWallet()', async () => {
+                  await resetBeaconWallet()
+                  return 'Called resetBeaconWallet() directly (destroy + rebuild).'
+                })
+              }
+            >
+              Force hard reset (destroy + rebuild)
+            </Button>
+
+            <Flex gap='6px'>
+              <Button
+                size='xs'
+                flex='1'
+                variant='outline'
+                color='#eee'
+                borderColor='#444'
+                disabled={busy}
+                onClick={() => refresh()}
+              >
+                Refresh
+              </Button>
+              <Button
+                size='xs'
+                flex='1'
+                variant='outline'
+                color='#eee'
+                borderColor='#444'
+                onClick={() => window.location.reload()}
+              >
+                Reload page
+              </Button>
+            </Flex>
+          </Flex>
+
+          {log && (
+            <Box mb='8px' p='6px' bg='#000' borderRadius='6px' color='#9cf'>
+              {log}
+            </Box>
+          )}
+
+          <Text color='#888' mb='4px'>
+            localStorage beacon keys ({entries.length}):
+          </Text>
+          {entries.map(e => (
+            <Text key={e.key} color='#ccc' wordBreak='break-all' mb='2px'>
+              • {e.key} <Text as='span' color='#666'>({e.size}b)</Text>
+            </Text>
+          ))}
+
+          <Text color='#888' mt='6px' mb='4px'>
+            IndexedDB ({dbs.length}):
+          </Text>
+          {dbs.map(name => (
+            <Text key={name} color='#ccc' wordBreak='break-all'>
+              • {name}
+            </Text>
+          ))}
+        </>
+      )}
+    </Box>
+  )
+}

--- a/components/BeaconDebugPanel.tsx
+++ b/components/BeaconDebugPanel.tsx
@@ -12,9 +12,16 @@ import {
 
 const FLAG_KEY = 'beaconDebug'
 
-// Enabled in dev automatically, or on any build by visiting `?beaconDebug=1`
-// (persisted to localStorage). `?beaconDebug=0` turns it back off. This lets us
-// reproduce the Safari failure on a real deployed URL where ITP actually runs.
+// The panel is OFF by default. It turns on when either:
+//  - the build-time env var NEXT_PUBLIC_BEACON_DEBUG is "true"/"1", or
+//  - the runtime ?beaconDebug=1 query param is used (persisted to localStorage;
+//    ?beaconDebug=0 clears it) — handy for a deployed build where ITP runs.
+// A missing/empty env var is treated as off (no crash).
+const envDebugEnabled = () => {
+  const value = process.env.NEXT_PUBLIC_BEACON_DEBUG
+  return value === 'true' || value === '1'
+}
+
 const useDebugEnabled = () => {
   const [enabled, setEnabled] = useState(false)
   useEffect(() => {
@@ -22,10 +29,7 @@ const useDebugEnabled = () => {
     const param = params.get(FLAG_KEY)
     if (param === '1') localStorage.setItem(FLAG_KEY, '1')
     if (param === '0') localStorage.removeItem(FLAG_KEY)
-    setEnabled(
-      process.env.NODE_ENV !== 'production' ||
-        localStorage.getItem(FLAG_KEY) === '1'
-    )
+    setEnabled(envDebugEnabled() || localStorage.getItem(FLAG_KEY) === '1')
   }, [])
   return enabled
 }

--- a/components/BeaconDebugPanel.tsx
+++ b/components/BeaconDebugPanel.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Box, Button, Flex, Text } from '@chakra-ui/react'
 import { useConnection } from '@/providers/ConnectionProvider'
-import { resetBeaconWallet } from '@/providers/ConnectionProvider/beacon'
 import {
   clearAllBeaconStorage,
   listBeaconStorage,
@@ -172,21 +171,6 @@ export const BeaconDebugPanel = () => {
               }
             >
               Test app disconnect() (commit 1)
-            </Button>
-
-            <Button
-              size='xs'
-              bg='#357'
-              color='white'
-              disabled={busy}
-              onClick={() =>
-                run('resetBeaconWallet()', async () => {
-                  await resetBeaconWallet()
-                  return 'Called resetBeaconWallet() directly (destroy + rebuild).'
-                })
-              }
-            >
-              Force hard reset (destroy + rebuild)
             </Button>
 
             <Button

--- a/components/BeaconDebugPanel.tsx
+++ b/components/BeaconDebugPanel.tsx
@@ -122,7 +122,7 @@ export const BeaconDebugPanel = () => {
               onClick={() =>
                 run('Simulate ITP eviction', async () => {
                   const r = await simulateItpEviction()
-                  return `Removed ${r.removedKeys.length} transport keys + ${r.removedDatabases.length} IndexedDB db(s); kept ${r.keptKeys.length} identity keys. Now reload — with the fix the app should recover to "disconnected" within ~12s instead of hanging.`
+                  return `Removed ${r.removedKeys.length} transport keys + ${r.removedDatabases.length} IndexedDB db(s) [${r.removedDatabases.join(', ') || 'none'}]; kept ${r.keptKeys.length} main identity keys. Reload: the app should NOT be usable against the dead transport — either the init probe self-heals to "disconnected", or a later operation fails. Compare against "Test app disconnect()" for the deterministic check.`
                 })
               }
             >
@@ -167,7 +167,7 @@ export const BeaconDebugPanel = () => {
               onClick={() =>
                 run('App disconnect()', async () => {
                   await disconnect()
-                  return 'Called the app\'s disconnect(). Storage below should now be empty of transport/peer/seed keys.'
+                  return 'Called the app\'s disconnect(). Deterministic check: NO account/active-account/transport (P2P-/WALLET-) key should remain below. A fresh client immediately re-seeds a couple of identity keys (sdk_version, seed) and an empty "beacon" IndexedDB — that is expected; the point is that no connected-session state survives.'
                 })
               }
             >

--- a/components/BeaconDebugPanel.tsx
+++ b/components/BeaconDebugPanel.tsx
@@ -33,7 +33,7 @@ const useDebugEnabled = () => {
 
 export const BeaconDebugPanel = () => {
   const enabled = useDebugEnabled()
-  const { isConnected, address, disconnect } = useConnection()
+  const { isConnected, address, disconnect, resetConnection } = useConnection()
   const [entries, setEntries] = useState<StorageEntry[]>([])
   const [dbs, setDbs] = useState<string[]>([])
   const [log, setLog] = useState<string>('')
@@ -187,6 +187,16 @@ export const BeaconDebugPanel = () => {
               }
             >
               Force hard reset (destroy + rebuild)
+            </Button>
+
+            <Button
+              size='xs'
+              bg='#357'
+              color='white'
+              disabled={busy}
+              onClick={() => resetConnection()}
+            >
+              Test resetConnection() (purge + reload to /)
             </Button>
 
             <Flex gap='6px'>

--- a/components/BeaconDebugPanel.tsx
+++ b/components/BeaconDebugPanel.tsx
@@ -122,7 +122,7 @@ export const BeaconDebugPanel = () => {
               onClick={() =>
                 run('Simulate ITP eviction', async () => {
                   const r = await simulateItpEviction()
-                  return `Removed ${r.removedKeys.length} transport keys + ${r.removedDatabases.length} IndexedDB db(s) [${r.removedDatabases.join(', ') || 'none'}]; kept ${r.keptKeys.length} main identity keys. Reload: the app should NOT be usable against the dead transport — either the init probe self-heals to "disconnected", or a later operation fails. Compare against "Test app disconnect()" for the deterministic check.`
+                  return `Removed ${r.removedKeys.length} transport/peer keys [${r.removedKeys.join(', ') || 'none'}] + ${r.removedDatabases.length} IndexedDB db(s) [${r.removedDatabases.join(', ') || 'none'}]; kept ${r.keptKeys.length} identity keys. Reload: the account now has no peer, so the app should show "disconnected" (Connect). A later operation would also drop to Connect.`
                 })
               }
             >

--- a/components/BeaconDebugPanel.tsx
+++ b/components/BeaconDebugPanel.tsx
@@ -7,6 +7,7 @@ import {
   listBeaconStorage,
   listIndexedDbDatabases,
   simulateItpEviction,
+  simulateStaleLastSelectedWallet,
   StorageEntry
 } from '@/utils/beaconDebug'
 
@@ -126,6 +127,21 @@ export const BeaconDebugPanel = () => {
               }
             >
               Simulate ITP eviction (dead transport)
+            </Button>
+
+            <Button
+              size='xs'
+              bg='#a33'
+              color='white'
+              disabled={busy}
+              onClick={() =>
+                run('Simulate stale wallet key', async () => {
+                  const key = simulateStaleLastSelectedWallet()
+                  return `Wrote ${key} = "temple_chrome" (string). Reload: without the fix the app crashes with "Cannot create property 'name' on string"; with the sanitizer it removes the key and loads.`
+                })
+              }
+            >
+              Simulate stale last-selected-wallet (crash)
             </Button>
 
             <Button

--- a/components/BeaconDebugPanel.tsx
+++ b/components/BeaconDebugPanel.tsx
@@ -10,32 +10,17 @@ import {
   StorageEntry
 } from '@/utils/beaconDebug'
 
-const FLAG_KEY = 'beaconDebug'
-
-// The panel is OFF by default. It turns on when either:
-//  - the build-time env var NEXT_PUBLIC_BEACON_DEBUG is "true"/"1", or
-//  - the runtime ?beaconDebug=1 query param is used (persisted to localStorage;
-//    ?beaconDebug=0 clears it) — handy for a deployed build where ITP runs.
-// A missing/empty env var is treated as off (no crash).
-const envDebugEnabled = () => {
+// The panel is OFF by default and gated solely on the build-time env var
+// NEXT_PUBLIC_BEACON_DEBUG ("true"/"1" to show it). A missing/empty value is
+// treated as off — no crash. The env var is inlined at build time, so it is
+// stable across server and client render (no hydration flip needed).
+const beaconDebugEnabled = () => {
   const value = process.env.NEXT_PUBLIC_BEACON_DEBUG
   return value === 'true' || value === '1'
 }
 
-const useDebugEnabled = () => {
-  const [enabled, setEnabled] = useState(false)
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search)
-    const param = params.get(FLAG_KEY)
-    if (param === '1') localStorage.setItem(FLAG_KEY, '1')
-    if (param === '0') localStorage.removeItem(FLAG_KEY)
-    setEnabled(envDebugEnabled() || localStorage.getItem(FLAG_KEY) === '1')
-  }, [])
-  return enabled
-}
-
 export const BeaconDebugPanel = () => {
-  const enabled = useDebugEnabled()
+  const enabled = beaconDebugEnabled()
   const { isConnected, address, disconnect, resetConnection } = useConnection()
   const [entries, setEntries] = useState<StorageEntry[]>([])
   const [dbs, setDbs] = useState<string[]>([])

--- a/components/Operations/operations.ts
+++ b/components/Operations/operations.ts
@@ -1,18 +1,71 @@
-import { PermissionScope } from '@tezos-x/octez.connect-sdk'
 import { TezosToolkit } from '@tezos-x/octez.js'
 import { BeaconWallet } from '@tezos-x/octez.js-dapp-wallet'
-import { requestBeaconPermissions } from '@/providers/ConnectionProvider/beacon'
+import { BeaconError } from '@tezos-x/octez.connect-sdk'
+
 export interface OperationResult {
   success: boolean
   opHash: string
   message: string
+  // True when the failure means the wallet connection itself is gone, so the
+  // app should drop back to a clean "connect" state (a fresh visit) rather than
+  // show an operation error.
+  connectionLost?: boolean
 }
-import { BeaconError } from '@tezos-x/octez.connect-sdk'
+
+// A dead/evicted transport session makes the wallet call hang with no
+// rejection. Time-box the request (not the on-chain confirmation) so we can
+// recover instead of spinning forever. Generous, since a live request also
+// waits for the user to approve in their wallet.
+const OP_TIMEOUT_MS = 180_000
+
+class ConnectionLostError extends Error {}
+class OpTimeoutError extends Error {}
+
+const withTimeout = <T,>(promise: Promise<T>, ms: number): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new OpTimeoutError()), ms)
+    promise.then(
+      value => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      error => {
+        clearTimeout(timer)
+        reject(error)
+      }
+    )
+  })
+
+// Distinguish "the connection is dead" from a normal operation failure (user
+// rejection, insufficient funds, a chain error). Kept intentionally tight to
+// Beacon transport semantics so a slow RPC / chain error is never mistaken for
+// a lost connection.
+const isConnectionError = (err: any): boolean => {
+  if (err instanceof ConnectionLostError || err instanceof OpTimeoutError) {
+    return true
+  }
+  const text = `${err?.name ?? ''} ${err?.message ?? ''}`.toLowerCase()
+  return [
+    'no active account',
+    'not connected',
+    'no active peer',
+    'transport error',
+    'messaging could not be started'
+  ].some(hint => text.includes(hint))
+}
+
+const connectionLostResult = (): OperationResult => ({
+  success: false,
+  opHash: '',
+  message: '',
+  connectionLost: true
+})
 
 async function checkActiveAccount(wallet: BeaconWallet) {
   const activeAccount = await wallet.client.getActiveAccount()
   if (!activeAccount) {
-    await requestBeaconPermissions(wallet)
+    // No active account at operation time means we are not really connected.
+    throw new ConnectionLostError('No active account')
   }
 }
 
@@ -24,12 +77,16 @@ export const setDelegate = async (
   let opHash = ''
   try {
     await checkActiveAccount(wallet)
-    const op = await Tezos.wallet.setDelegate({ delegate }).send()
+    const op = await withTimeout(
+      Tezos.wallet.setDelegate({ delegate }).send(),
+      OP_TIMEOUT_MS
+    )
     const response = await op.confirmation()
     opHash = op.opHash
     const success = response?.completed ?? false
     return { success, opHash, message: '' }
   } catch (err: any) {
+    if (isConnectionError(err)) return connectionLostResult()
     return {
       success: false,
       opHash: '',
@@ -47,11 +104,15 @@ export const stake = async (
   try {
     await checkActiveAccount(wallet)
 
-    const op = await Tezos.wallet.stake({ amount }).send()
+    const op = await withTimeout(
+      Tezos.wallet.stake({ amount }).send(),
+      OP_TIMEOUT_MS
+    )
     const response = await op.confirmation()
     const success = response?.completed ?? false
     return { success, opHash, message: '' }
   } catch (err: any) {
+    if (isConnectionError(err)) return connectionLostResult()
     return {
       success: false,
       opHash: '',
@@ -69,12 +130,16 @@ export const unstake = async (
   try {
     await checkActiveAccount(wallet)
 
-    const op = await Tezos.wallet.unstake({ amount }).send()
+    const op = await withTimeout(
+      Tezos.wallet.unstake({ amount }).send(),
+      OP_TIMEOUT_MS
+    )
     const response = await op.confirmation()
     opHash = op.opHash
     const success = response?.completed ?? false
     return { success, opHash, message: '' }
   } catch (err: any) {
+    if (isConnectionError(err)) return connectionLostResult()
     return {
       success: false,
       opHash: '',
@@ -90,12 +155,16 @@ export const finalizeUnstake = async (
   let opHash = ''
   try {
     await checkActiveAccount(wallet)
-    const op = await Tezos.wallet.finalizeUnstake({}).send()
+    const op = await withTimeout(
+      Tezos.wallet.finalizeUnstake({}).send(),
+      OP_TIMEOUT_MS
+    )
     const response = await op.confirmation()
     opHash = op.opHash
     const success = response?.completed ?? false
     return { success, opHash, message: '' }
   } catch (err: any) {
+    if (isConnectionError(err)) return connectionLostResult()
     return {
       success: false,
       opHash: '',

--- a/components/Operations/operations.ts
+++ b/components/Operations/operations.ts
@@ -109,6 +109,7 @@ export const stake = async (
       OP_TIMEOUT_MS
     )
     const response = await op.confirmation()
+    opHash = op.opHash
     const success = response?.completed ?? false
     return { success, opHash, message: '' }
   } catch (err: any) {

--- a/components/operationModals/Delegate/ConfirmBaker.tsx
+++ b/components/operationModals/Delegate/ConfirmBaker.tsx
@@ -43,7 +43,7 @@ export const ConfirmBaker = ({
   isStaked,
   canStake
 }: ChooseBakerProps) => {
-  const { Tezos, beaconWallet } = useConnection()
+  const { Tezos, beaconWallet, resetConnection } = useConnection()
   const { setMessage, setSuccess, setTitle, setOpHash, setOpType } =
     useOperationResponse()
   const [errorMessage, setErrorMessage] = useState('')
@@ -129,6 +129,10 @@ export const ConfirmBaker = ({
             beaconWallet
           )
           setWaitingOperation(false)
+          if (response.connectionLost) {
+            await resetConnection()
+            return
+          }
           if (response.success) {
             if (!canStake && handleNStepForward) {
               setOpType('pending_unstake')

--- a/components/operationModals/EndDelegate/ConfirmEndDelegate.tsx
+++ b/components/operationModals/EndDelegate/ConfirmEndDelegate.tsx
@@ -23,7 +23,7 @@ export const ConfirmEndDelegate = ({
   handleOneStepForward,
   bakerName
 }: ConfirmEndDelegate) => {
-  const { Tezos, beaconWallet } = useConnection()
+  const { Tezos, beaconWallet, resetConnection } = useConnection()
   const { setMessage, setSuccess, setOpHash, setTitle, setOpType } =
     useOperationResponse()
   const [errorMessage, setErrorMessage] = useState('')
@@ -51,6 +51,10 @@ export const ConfirmEndDelegate = ({
           setWaitingOperation(true)
           const response = await setDelegate(Tezos, undefined, beaconWallet)
           setWaitingOperation(false)
+          if (response.connectionLost) {
+            await resetConnection()
+            return
+          }
           if (response.success) {
             trackGAEvent(GAAction.BUTTON_CLICK, GACategory.END_DELEGATE_END)
             setOpHash(response.opHash)

--- a/components/operationModals/Stake/DisclaimerStaking.tsx
+++ b/components/operationModals/Stake/DisclaimerStaking.tsx
@@ -20,7 +20,7 @@ export const DisclaimerStaking = ({
   handleOneStepForward: () => void
   setStakedAmount: (arg: number) => void
 }) => {
-  const { Tezos, beaconWallet } = useConnection()
+  const { Tezos, beaconWallet, resetConnection } = useConnection()
   const [errorMessage, setErrorMessage] = useState('')
   const [waitingOperation, setWaitingOperation] = useState(false)
   const { setMessage, setSuccess, setAmount, setOpHash, setOpType } =
@@ -109,6 +109,11 @@ export const DisclaimerStaking = ({
           setWaitingOperation(true)
           const response = await stake(Tezos, stakedAmount, beaconWallet)
           setWaitingOperation(false)
+
+          if (response.connectionLost) {
+            await resetConnection()
+            return
+          }
 
           if (response.success) {
             trackGAEvent(GAAction.BUTTON_CLICK, GACategory.START_STAKE_END)

--- a/components/operationModals/Unstake/SelectAmount.tsx
+++ b/components/operationModals/Unstake/SelectAmount.tsx
@@ -19,7 +19,7 @@ export const SelectAmount = ({
   setUnstakeAmount: (arg: number) => void
   handleOneStepForward: () => void
 }) => {
-  const { Tezos, beaconWallet } = useConnection()
+  const { Tezos, beaconWallet, resetConnection } = useConnection()
   const { setMessage, setSuccess, setAmount, setOpHash, setTitle, setOpType } =
     useOperationResponse()
   const [errorMessage, setErrorMessage] = useState('')
@@ -86,6 +86,11 @@ export const SelectAmount = ({
           setWaitingOperation(true)
           const response = await unstake(Tezos, unstakeAmount, beaconWallet)
           setWaitingOperation(false)
+
+          if (response.connectionLost) {
+            await resetConnection()
+            return
+          }
 
           if (response.success) {
             trackGAEvent(GAAction.BUTTON_CLICK, GACategory.END_STAKE_END)

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import { Provider } from '@/components/ui/provider'
 import { ConnectionProvider } from '@/providers/ConnectionProvider'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { OperationResponseProvider } from '@/providers/OperationResponseProvider'
+import { BeaconDebugPanel } from '@/components/BeaconDebugPanel'
 import { useEffect } from 'react'
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
@@ -29,6 +30,7 @@ export default function App({ Component, pageProps }: AppProps) {
           <ConnectionProvider>
             <Provider>
               <Component {...pageProps} />
+              <BeaconDebugPanel />
             </Provider>
           </ConnectionProvider>
         </QueryClientProvider>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,20 +13,31 @@ const queryClient = new QueryClient()
 
 export default function App({ Component, pageProps }: AppProps) {
   useEffect(() => {
-    // The Beacon Matrix (P2P) transport rejects its in-flight sync with a
-    // benign "Syncing stopped manually" error whenever the client is torn down
-    // (e.g. on a disconnect/reload). Nothing awaits it, so it would otherwise
-    // surface as an unhandled rejection / dev error overlay. Swallow only that
-    // exact message; everything else propagates normally.
+    // Beacon spins up several wallet transports at once, and the ones the user
+    // does not pick emit benign background rejections that nothing awaits — so
+    // they surface as unhandled rejections / dev error overlays even though the
+    // real connection is fine:
+    //  - "Syncing stopped manually": Matrix (P2P) transport torn down.
+    //  - "Proposal expired" / "Pairing expired": WalletConnect proposal/pairing
+    //    TTL elapses (~5 min) when the WC QR option is left unused.
+    // Swallow only this known-benign set; every other rejection propagates.
+    const BENIGN_WALLET_REJECTIONS = [
+      'Syncing stopped manually',
+      'Proposal expired',
+      'Pairing expired'
+    ]
     const onRejection = (event: PromiseRejectionEvent) => {
       const reason: any = event.reason
       const message = String(reason?.message ?? reason ?? '')
-      if (message.includes('Syncing stopped manually')) {
+      if (BENIGN_WALLET_REJECTIONS.some(m => message.includes(m))) {
         event.preventDefault()
+        event.stopImmediatePropagation()
       }
     }
-    window.addEventListener('unhandledrejection', onRejection)
-    return () => window.removeEventListener('unhandledrejection', onRejection)
+    // Capture phase so we run before Next's dev-overlay listener where possible.
+    window.addEventListener('unhandledrejection', onRejection, true)
+    return () =>
+      window.removeEventListener('unhandledrejection', onRejection, true)
   }, [])
 
   useEffect(() => {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,6 +13,23 @@ const queryClient = new QueryClient()
 
 export default function App({ Component, pageProps }: AppProps) {
   useEffect(() => {
+    // The Beacon Matrix (P2P) transport rejects its in-flight sync with a
+    // benign "Syncing stopped manually" error whenever the client is torn down
+    // (e.g. on a disconnect/reload). Nothing awaits it, so it would otherwise
+    // surface as an unhandled rejection / dev error overlay. Swallow only that
+    // exact message; everything else propagates normally.
+    const onRejection = (event: PromiseRejectionEvent) => {
+      const reason: any = event.reason
+      const message = String(reason?.message ?? reason ?? '')
+      if (message.includes('Syncing stopped manually')) {
+        event.preventDefault()
+      }
+    }
+    window.addEventListener('unhandledrejection', onRejection)
+    return () => window.removeEventListener('unhandledrejection', onRejection)
+  }, [])
+
+  useEffect(() => {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
       api_host:
         process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',

--- a/providers/ConnectionProvider/beacon.ts
+++ b/providers/ConnectionProvider/beacon.ts
@@ -137,6 +137,38 @@ export async function purgeBeaconStorage(): Promise<void> {
 }
 
 /**
+ * True when storage holds at least one paired peer (a `*peers*` record with a
+ * non-empty array). Beacon records the connected wallet as a peer, so an active
+ * account with NO peer means the transport session was evicted — a dead
+ * connection we should treat as disconnected rather than trust.
+ *
+ * Fail-safe: if storage can't be read we return true so a valid session is
+ * never dropped by mistake; we only report "no peer" after a clean scan.
+ */
+export function hasBeaconPeer(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i)
+      if (!key || !key.toLowerCase().includes('beacon:')) continue
+      if (!key.toLowerCase().includes('peers')) continue
+      const raw = localStorage.getItem(key)
+      if (!raw) continue
+      try {
+        const parsed = JSON.parse(raw)
+        if (Array.isArray(parsed) && parsed.length > 0) return true
+      } catch {
+        // A non-JSON peer value still implies a peer; stay safe and keep it.
+        if (raw.trim().length > 2) return true
+      }
+    }
+  } catch {
+    return true
+  }
+  return false
+}
+
+/**
  * Fully tears down the current Beacon connection and rebuilds a fresh client.
  *
  * `BeaconWallet.disconnect()` (-> `client.destroy()`) gracefully disconnects

--- a/providers/ConnectionProvider/beacon.ts
+++ b/providers/ConnectionProvider/beacon.ts
@@ -168,34 +168,6 @@ export function hasBeaconPeer(): boolean {
   return false
 }
 
-/**
- * Fully tears down the current Beacon connection and rebuilds a fresh client.
- *
- * `BeaconWallet.disconnect()` (-> `client.destroy()`) gracefully disconnects
- * the transport, but only clears the main client's unprefixed keys — so we
- * follow it with a full purgeBeaconStorage() to remove the transport-scoped
- * namespaces and IndexedDB too. The singleton is dropped and a brand new
- * client built for the next connect.
- *
- * This is the programmatic equivalent of the "clear site data" step users
- * previously had to perform by hand on Safari.
- */
-export async function resetBeaconWallet(): Promise<BeaconWallet | undefined> {
-  if (typeof window === 'undefined') return undefined
-  const existing = g.__BEACON_WALLET__ as BeaconWallet | undefined
-  if (existing) {
-    try {
-      await existing.disconnect()
-    } catch (error) {
-      console.warn('[beacon] reset: destroy failed, purging anyway', error)
-    }
-  }
-  // Drop the reference before purging so open IndexedDB connections can close.
-  g.__BEACON_WALLET__ = undefined
-  await purgeBeaconStorage()
-  return createBeaconWallet()
-}
-
 export async function requestBeaconPermissions(wallet: BeaconWallet) {
   return await wallet.client.requestPermissions({
     scopes: [PermissionScope.OPERATION_REQUEST, PermissionScope.SIGN]

--- a/providers/ConnectionProvider/beacon.ts
+++ b/providers/ConnectionProvider/beacon.ts
@@ -97,16 +97,15 @@ const deleteIndexedDb = (name: string): Promise<void> =>
   })
 
 /**
- * Remove every persisted trace of Beacon.
+ * Synchronously remove every `beacon:*` localStorage key.
  *
- * `client.destroy()` only clears the *main* client's unprefixed `beacon:*`
- * keys. The SDK also keeps transport-scoped copies under `P2P-beacon:*` /
- * `WALLET-beacon:*`, plus IndexedDB databases (`beacon` for metrics/bug-report
- * and `WALLET_CONNECT_V2_INDEXED_DB` for the WC session). Those survive
- * destroy() and are exactly the stale state that used to force a manual
- * "clear site data" on Safari, so wipe all of it here.
+ * `client.destroy()` only clears the *main* client's unprefixed keys; the SDK
+ * also keeps transport-scoped copies under `P2P-beacon:*` / `WALLET-beacon:*`.
+ * These keys (active-account, peers, seed) are what gate connection state, so
+ * clearing them synchronously is sufficient for a reloaded page to come up
+ * disconnected. This is the part that must always run before a reload.
  */
-export async function purgeBeaconStorage(): Promise<void> {
+export function purgeBeaconLocalStorage(): void {
   if (typeof window === 'undefined') return
   try {
     const keys: string[] = []
@@ -118,6 +117,19 @@ export async function purgeBeaconStorage(): Promise<void> {
   } catch (error) {
     console.warn('[beacon] purge: localStorage clear failed', error)
   }
+}
+
+/**
+ * Best-effort removal of the beacon IndexedDB databases (`beacon` metrics/
+ * bug-report store and `WALLET_CONNECT_V2_INDEXED_DB` WC session).
+ *
+ * IMPORTANT: this may never resolve on Safari — deleteDatabase() blocks on an
+ * open connection and Safari does not reliably fire onblocked/onsuccess. Callers
+ * that need to reload afterwards MUST NOT await this (fire-and-forget); the page
+ * reload closes the connections regardless.
+ */
+export async function purgeBeaconIndexedDb(): Promise<void> {
+  if (typeof window === 'undefined' || !window.indexedDB) return
   try {
     const factory = indexedDB as IDBFactory & {
       databases?: () => Promise<{ name?: string }[]>

--- a/providers/ConnectionProvider/beacon.ts
+++ b/providers/ConnectionProvider/beacon.ts
@@ -1,37 +1,69 @@
 import { BeaconWallet } from '@tezos-x/octez.js-dapp-wallet'
 import { TezosToolkit } from '@tezos-x/octez.js'
 import { RpcClient, RpcClientCache } from '@tezos-x/octez.js-rpc'
-import { NetworkType, PermissionScope, BeaconEvent } from '@tezos-x/octez.connect-sdk'
+import {
+  NetworkType,
+  PermissionScope,
+  BeaconEvent
+} from '@tezos-x/octez.connect-sdk'
 
 const rpc = new RpcClientCache(
   new RpcClient(process.env.NEXT_PUBLIC_RPC_ENDPOINT as string)
 )
 export const Tezos = new TezosToolkit(rpc)
 
-// Use a global singleton to prevent multiple instances across HMR/StrictMode
+// Use a global singleton to prevent multiple instances across HMR/StrictMode.
+// The Beacon SDK explicitly warns (and can corrupt its own storage) when more
+// than one DAppClient is constructed for the same origin, so we keep exactly
+// one live instance on globalThis.
 const g = globalThis as any
-if (typeof window !== 'undefined') {
-  if (!g.__BEACON_WALLET__) {
-    g.__BEACON_WALLET__ = new BeaconWallet({
-      name: 'Stake XTZ',
-      appUrl: window.location.origin,
-      network: { type: process.env.NEXT_PUBLIC_NETWORK as NetworkType },
-      featuredWallets: ['kukai', 'trust', 'temple', 'umami']
-    })
-  }
-  if (!g.__BEACON_SUBSCRIBED__ && g.__BEACON_WALLET__) {
-    g.__BEACON_WALLET__.client.subscribeToEvent(
-      BeaconEvent.ACTIVE_ACCOUNT_SET,
-      () => {}
-    )
-    g.__BEACON_SUBSCRIBED__ = true
-  }
+
+const buildBeaconWallet = (): BeaconWallet => {
+  const wallet = new BeaconWallet({
+    name: 'Stake XTZ',
+    appUrl: window.location.origin,
+    network: { type: process.env.NEXT_PUBLIC_NETWORK as NetworkType },
+    featuredWallets: ['kukai', 'trust', 'temple', 'umami']
+  })
+  // Keep a live subscription so the SDK reliably emits ACTIVE_ACCOUNT_SET.
+  wallet.client.subscribeToEvent(BeaconEvent.ACTIVE_ACCOUNT_SET, () => {})
+  return wallet
 }
 
-export const createBeaconWallet = () =>
-  typeof window === 'undefined'
-    ? undefined
-    : (g.__BEACON_WALLET__ as BeaconWallet)
+export const createBeaconWallet = (): BeaconWallet | undefined => {
+  if (typeof window === 'undefined') return undefined
+  if (!g.__BEACON_WALLET__) {
+    g.__BEACON_WALLET__ = buildBeaconWallet()
+  }
+  return g.__BEACON_WALLET__ as BeaconWallet
+}
+
+/**
+ * Fully tears down the current Beacon connection and rebuilds a fresh client.
+ *
+ * `BeaconWallet.disconnect()` calls `client.destroy()`, which disconnects the
+ * transport, runs the WalletConnect IndexedDB cleanup and deletes *every*
+ * `beacon:*` key from localStorage (secret seed, peers, matrix + walletconnect
+ * session state, accounts). After destroy() the instance is documented as no
+ * longer usable, so we drop the singleton and build a brand new one for the
+ * next connect.
+ *
+ * This is the programmatic equivalent of the "clear site data" step users
+ * previously had to perform by hand on Safari.
+ */
+export async function resetBeaconWallet(): Promise<BeaconWallet | undefined> {
+  if (typeof window === 'undefined') return undefined
+  const existing = g.__BEACON_WALLET__ as BeaconWallet | undefined
+  if (existing) {
+    try {
+      await existing.disconnect()
+    } catch (error) {
+      console.warn('[beacon] reset: destroy failed, rebuilding anyway', error)
+    }
+  }
+  g.__BEACON_WALLET__ = undefined
+  return createBeaconWallet()
+}
 
 export async function requestBeaconPermissions(wallet: BeaconWallet) {
   return await wallet.client.requestPermissions({

--- a/providers/ConnectionProvider/beacon.ts
+++ b/providers/ConnectionProvider/beacon.ts
@@ -18,7 +18,47 @@ export const Tezos = new TezosToolkit(rpc)
 // one live instance on globalThis.
 const g = globalThis as any
 
+/**
+ * Repair storage written by an older SDK build before the current SDK reads it.
+ *
+ * Older versions stored `beacon:last-selected-wallet` as a bare string (e.g.
+ * "temple_chrome"); this version expects an object and crashes in
+ * DAppClient.updateStorageWallet() with:
+ *   TypeError: Cannot create property 'name' on string 'temple_chrome'
+ * That write is not awaited inside the SDK, so it surfaces as an unhandled
+ * rejection that our connect/init self-heal cannot catch — the value has to be
+ * fixed before the SDK touches it. The key is cosmetic (wallet name/icon) and
+ * defaults to `undefined`, so removing an incompatible value is safe; the SDK
+ * repopulates it on the next successful connect.
+ */
+const sanitizeBeaconStorage = () => {
+  try {
+    for (let i = localStorage.length - 1; i >= 0; i--) {
+      const key = localStorage.key(i)
+      if (!key || !key.toLowerCase().includes('beacon:')) continue
+      if (!key.toLowerCase().includes('last-selected-wallet')) continue
+      const raw = localStorage.getItem(key)
+      if (raw === null) continue
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(raw)
+      } catch {
+        parsed = raw
+      }
+      if (typeof parsed !== 'object' || parsed === null) {
+        localStorage.removeItem(key)
+        console.warn(
+          `[beacon] removed incompatible storage key ${key} (was ${typeof parsed})`
+        )
+      }
+    }
+  } catch (error) {
+    console.warn('[beacon] storage sanitize failed', error)
+  }
+}
+
 const buildBeaconWallet = (): BeaconWallet => {
+  sanitizeBeaconStorage()
   const wallet = new BeaconWallet({
     name: 'Stake XTZ',
     appUrl: window.location.origin,

--- a/providers/ConnectionProvider/beacon.ts
+++ b/providers/ConnectionProvider/beacon.ts
@@ -78,15 +78,72 @@ export const createBeaconWallet = (): BeaconWallet | undefined => {
   return g.__BEACON_WALLET__ as BeaconWallet
 }
 
+// Names of every beacon-related IndexedDB database. `beacon` is the
+// DAppClient's bug-report/metrics store; WALLET_CONNECT_V2_INDEXED_DB is the
+// WalletConnect session store. Matched by substring so any variant is caught.
+const BEACON_IDB_HINTS = ['beacon', 'wallet_connect']
+
+const deleteIndexedDb = (name: string): Promise<void> =>
+  new Promise(resolve => {
+    try {
+      const request = indexedDB.deleteDatabase(name)
+      request.onsuccess = () => resolve()
+      request.onerror = () => resolve()
+      // A still-open connection defers the delete; don't block the reset on it.
+      request.onblocked = () => resolve()
+    } catch {
+      resolve()
+    }
+  })
+
+/**
+ * Remove every persisted trace of Beacon.
+ *
+ * `client.destroy()` only clears the *main* client's unprefixed `beacon:*`
+ * keys. The SDK also keeps transport-scoped copies under `P2P-beacon:*` /
+ * `WALLET-beacon:*`, plus IndexedDB databases (`beacon` for metrics/bug-report
+ * and `WALLET_CONNECT_V2_INDEXED_DB` for the WC session). Those survive
+ * destroy() and are exactly the stale state that used to force a manual
+ * "clear site data" on Safari, so wipe all of it here.
+ */
+export async function purgeBeaconStorage(): Promise<void> {
+  if (typeof window === 'undefined') return
+  try {
+    const keys: string[] = []
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i)
+      if (key && key.toLowerCase().includes('beacon:')) keys.push(key)
+    }
+    keys.forEach(key => localStorage.removeItem(key))
+  } catch (error) {
+    console.warn('[beacon] purge: localStorage clear failed', error)
+  }
+  try {
+    const factory = indexedDB as IDBFactory & {
+      databases?: () => Promise<{ name?: string }[]>
+    }
+    let names: string[] = []
+    if (typeof factory.databases === 'function') {
+      names = (await factory.databases()).map(d => d.name ?? '').filter(Boolean)
+    }
+    if (!names.length) names = ['beacon', 'WALLET_CONNECT_V2_INDEXED_DB']
+    const targets = names.filter(name =>
+      BEACON_IDB_HINTS.some(hint => name.toLowerCase().includes(hint))
+    )
+    await Promise.all(targets.map(deleteIndexedDb))
+  } catch (error) {
+    console.warn('[beacon] purge: indexedDB clear failed', error)
+  }
+}
+
 /**
  * Fully tears down the current Beacon connection and rebuilds a fresh client.
  *
- * `BeaconWallet.disconnect()` calls `client.destroy()`, which disconnects the
- * transport, runs the WalletConnect IndexedDB cleanup and deletes *every*
- * `beacon:*` key from localStorage (secret seed, peers, matrix + walletconnect
- * session state, accounts). After destroy() the instance is documented as no
- * longer usable, so we drop the singleton and build a brand new one for the
- * next connect.
+ * `BeaconWallet.disconnect()` (-> `client.destroy()`) gracefully disconnects
+ * the transport, but only clears the main client's unprefixed keys — so we
+ * follow it with a full purgeBeaconStorage() to remove the transport-scoped
+ * namespaces and IndexedDB too. The singleton is dropped and a brand new
+ * client built for the next connect.
  *
  * This is the programmatic equivalent of the "clear site data" step users
  * previously had to perform by hand on Safari.
@@ -98,10 +155,12 @@ export async function resetBeaconWallet(): Promise<BeaconWallet | undefined> {
     try {
       await existing.disconnect()
     } catch (error) {
-      console.warn('[beacon] reset: destroy failed, rebuilding anyway', error)
+      console.warn('[beacon] reset: destroy failed, purging anyway', error)
     }
   }
+  // Drop the reference before purging so open IndexedDB connections can close.
   g.__BEACON_WALLET__ = undefined
+  await purgeBeaconStorage()
   return createBeaconWallet()
 }
 

--- a/providers/ConnectionProvider/index.tsx
+++ b/providers/ConnectionProvider/index.tsx
@@ -12,6 +12,7 @@ import {
   createBeaconWallet,
   resetBeaconWallet,
   purgeBeaconStorage,
+  hasBeaconPeer,
   Tezos as TzosInstance,
   requestBeaconPermissions
 } from './beacon'
@@ -140,12 +141,20 @@ export const ConnectionProvider = ({ children }: { children: any }) => {
         return
       }
 
-      // There is a restored session. Verify the transport can actually be
-      // re-established before trusting it — on Safari the account can survive
-      // while its transport session is dead, which used to leave the app stuck
-      // "connected" with every operation hanging. If the probe hangs or throws,
-      // self-heal by wiping the poisoned state so the user can reconnect
-      // cleanly, rather than having to clear site data by hand.
+      // A restored account with no paired peer means the transport session was
+      // evicted (classic Safari ITP): the account survives but the connection
+      // is dead. Deterministically treat that as disconnected — a fresh visit —
+      // instead of trusting the stale account.
+      if (!hasBeaconPeer()) {
+        console.warn('[beacon] active account has no peer, resetting to connect')
+        await hardReset()
+        return
+      }
+
+      // Peer present, so the session should be live. Verify the transport can
+      // actually be re-established before trusting it; if init() hangs or
+      // throws, self-heal by wiping the poisoned state rather than making the
+      // user clear site data by hand.
       try {
         await withTimeout(wallet.client.init(), INIT_TIMEOUT_MS, 'client.init')
         applyActiveAccount(activeAccount)

--- a/providers/ConnectionProvider/index.tsx
+++ b/providers/ConnectionProvider/index.tsx
@@ -10,7 +10,8 @@ import { WalletApi } from './types'
 import { TezosToolkit } from '@tezos-x/octez.js'
 import {
   createBeaconWallet,
-  purgeBeaconStorage,
+  purgeBeaconLocalStorage,
+  purgeBeaconIndexedDb,
   hasBeaconPeer,
   Tezos as TzosInstance,
   requestBeaconPermissions
@@ -76,17 +77,20 @@ export const ConnectionProvider = ({ children }: { children: any }) => {
     }
   }
 
-  // "Fresh visit": the single way we ever drop to a disconnected state. Purge
-  // every beacon store and reload — the reloaded page constructs exactly one
-  // clean client. We deliberately do NOT call the SDK's destroy() here:
-  //  - destroy-and-rebuild in place races with the client's async init (doubly
-  //    so under StrictMode's double-invoked mount effect) and leaves the next
-  //    connect with no answer from the wallet;
-  //  - destroy() also stops the Matrix transport mid-sync, which rejects with a
-  //    benign "Syncing stopped manually" error that surfaces in the dev overlay.
-  // The page reload tears everything down cleanly instead.
-  const freshVisit = async () => {
-    await purgeBeaconStorage()
+  // "Fresh visit": the single way we ever drop to a disconnected state. Clear
+  // the localStorage keys that gate connection state (synchronous) and reload —
+  // the reloaded page constructs exactly one clean client. Notes:
+  //  - We do NOT call the SDK's destroy() (it races with the client's async
+  //    init — doubly so under StrictMode — and stops the Matrix transport
+  //    mid-sync, emitting a benign "Syncing stopped manually" rejection). The
+  //    reload tears everything down cleanly instead.
+  //  - We do NOT await the IndexedDB purge: on Safari deleteDatabase() hangs on
+  //    an open connection, which would block the reload forever (the "disconnect
+  //    does nothing until you refresh" bug). Fire it best-effort; the reload
+  //    closes the connections anyway.
+  const freshVisit = () => {
+    purgeBeaconLocalStorage()
+    void purgeBeaconIndexedDb()
     if (typeof window !== 'undefined') window.location.href = '/'
   }
 
@@ -113,7 +117,7 @@ export const ConnectionProvider = ({ children }: { children: any }) => {
       // is dead. Treat it as a fresh visit rather than trusting a dead account.
       if (!hasBeaconPeer()) {
         console.warn('[beacon] active account has no peer; resetting to connect')
-        await freshVisit()
+        freshVisit()
         return
       }
 
@@ -154,15 +158,15 @@ export const ConnectionProvider = ({ children }: { children: any }) => {
             })
         },
         disconnect: async () => {
-          // Fresh visit: purge every beacon store (main + transport namespaces
-          // + IndexedDB) and reload to the connect screen. This is what stops
-          // Safari from ever needing a manual "clear site data".
-          await freshVisit()
+          // Fresh visit: clear beacon localStorage and reload to the connect
+          // screen (IndexedDB cleared best-effort, non-blocking). This is what
+          // stops Safari from ever needing a manual "clear site data".
+          freshVisit()
         },
         resetConnection: async () => {
           // A lost/dead connection is treated exactly like a disconnect: fresh
           // visit. You are either connected or you are not.
-          await freshVisit()
+          freshVisit()
         },
         address,
         isConnected,

--- a/providers/ConnectionProvider/index.tsx
+++ b/providers/ConnectionProvider/index.tsx
@@ -28,6 +28,44 @@ interface ConnectionContextType extends Partial<WalletApi> {
 
 const ConnectionContext = createContext<ConnectionContextType | null>(null)
 
+// A stale Beacon session (e.g. after Safari ITP evicts part of the store) makes
+// the transport hang forever with no rejection. Time-box those calls so we can
+// detect the hang and self-heal instead of leaving the user stuck.
+//
+// - INIT: getActiveAccount() is instant, but client.init() re-establishes the
+//   transport for a restored session and is where a dead peer hangs. A healthy
+//   session settles in well under a second, so a generous ceiling only ever
+//   elapses in the genuinely-broken case.
+// - CONNECT: requestPermissions() legitimately waits for the user to approve in
+//   their wallet, so this is a long backstop against a never-settling promise,
+//   not a UX deadline.
+const INIT_TIMEOUT_MS = 12_000
+const CONNECT_TIMEOUT_MS = 180_000
+
+class TimeoutError extends Error {}
+
+const withTimeout = <T,>(
+  promise: Promise<T>,
+  ms: number,
+  label: string
+): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new TimeoutError(`${label} timed out after ${ms}ms`)),
+      ms
+    )
+    promise.then(
+      value => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      error => {
+        clearTimeout(timer)
+        reject(error)
+      }
+    )
+  })
+
 export const ConnectionProvider = ({ children }: { children: any }) => {
   const [address, setAddress] = useState<string | undefined>(undefined)
   const [Tezos, setTezos] = useState<TezosToolkit | undefined>(undefined)
@@ -89,14 +127,29 @@ export const ConnectionProvider = ({ children }: { children: any }) => {
   // On mount, sync active account and set provider
   useEffect(() => {
     const init = async () => {
+      const wallet = walletRef.current
+      subscribeWallet(wallet)
+      const activeAccount = await wallet?.client
+        .getActiveAccount()
+        .catch(() => undefined)
+
+      if (!activeAccount || !wallet) {
+        reset()
+        return
+      }
+
+      // There is a restored session. Verify the transport can actually be
+      // re-established before trusting it — on Safari the account can survive
+      // while its transport session is dead, which used to leave the app stuck
+      // "connected" with every operation hanging. If the probe hangs or throws,
+      // self-heal by wiping the poisoned state so the user can reconnect
+      // cleanly, rather than having to clear site data by hand.
       try {
-        const wallet = walletRef.current
-        subscribeWallet(wallet)
-        const activeAccount = await wallet?.client.getActiveAccount()
+        await withTimeout(wallet.client.init(), INIT_TIMEOUT_MS, 'client.init')
         applyActiveAccount(activeAccount)
       } catch (error) {
-        console.error('Error:', error)
-        reset()
+        console.error('[beacon] stale session detected on init, resetting', error)
+        await hardReset()
       }
     }
     init()
@@ -111,22 +164,28 @@ export const ConnectionProvider = ({ children }: { children: any }) => {
           if (!wallet) {
             throw new Error('Wallet not initialized')
           }
-          return await requestBeaconPermissions(wallet)
-            .then(response => {
-              setAddress(response.address)
-              setIsConnected(true)
-              setBeaconWallet(wallet)
-              TzosInstance.setWalletProvider(wallet)
-              setTezos(TzosInstance)
-              trackGAEvent(GAAction.CONNECT_SUCCESS, GACategory.WALLET_SUCCESS)
-            })
-            .catch(() => {
-              reset()
-              trackGAEvent(GAAction.CONNECT_ERROR, GACategory.WALLET_ERROR)
-              throw new Error(
-                'Error connecting to wallet, please try again later'
-              )
-            })
+          try {
+            const response = await withTimeout(
+              requestBeaconPermissions(wallet),
+              CONNECT_TIMEOUT_MS,
+              'requestPermissions'
+            )
+            setAddress(response.address)
+            setIsConnected(true)
+            setBeaconWallet(wallet)
+            TzosInstance.setWalletProvider(wallet)
+            setTezos(TzosInstance)
+            trackGAEvent(GAAction.CONNECT_SUCCESS, GACategory.WALLET_SUCCESS)
+          } catch (error) {
+            // A failed or hung permission request usually means a poisoned
+            // transport. Wipe it so the next attempt starts from a clean
+            // client instead of retrying against the same broken state.
+            trackGAEvent(GAAction.CONNECT_ERROR, GACategory.WALLET_ERROR)
+            await hardReset()
+            throw new Error(
+              'Error connecting to wallet, please try again later'
+            )
+          }
         },
         disconnect: async () => {
           // `removeAllAccounts()` only cleared the account list and left the

--- a/providers/ConnectionProvider/index.tsx
+++ b/providers/ConnectionProvider/index.tsx
@@ -10,6 +10,7 @@ import { WalletApi } from './types'
 import { TezosToolkit } from '@tezos-x/octez.js'
 import {
   createBeaconWallet,
+  resetBeaconWallet,
   Tezos as TzosInstance,
   requestBeaconPermissions
 } from './beacon'
@@ -40,53 +41,67 @@ export const ConnectionProvider = ({ children }: { children: any }) => {
     walletRef.current = createBeaconWallet()
   }
 
-  // On mount, sync active account and set provider
-  useEffect(() => {
-    const init = async () => {
-      try {
-        const wallet = walletRef.current
-        // Ensure subscription exists before any account changes
-        if (wallet && !subscribedRef.current) {
-          wallet.client.subscribeToEvent(
-            BeaconEvent.ACTIVE_ACCOUNT_SET,
-            account => {
-              if (account && walletRef.current) {
-                setIsConnected(true)
-                setAddress(account.address)
-                setBeaconWallet(walletRef.current)
-                TzosInstance.setWalletProvider(walletRef.current)
-                setTezos(TzosInstance)
-              } else {
-                reset()
-              }
-            }
-          )
-          subscribedRef.current = true
-        }
-        const activeAccount = await wallet?.client.getActiveAccount()
-        if (activeAccount && wallet) {
-          setIsConnected(true)
-          setAddress(activeAccount.address)
-          setBeaconWallet(wallet)
-          TzosInstance.setWalletProvider(wallet)
-          setTezos(TzosInstance)
-        } else {
-          reset()
-        }
-      } catch (error) {
-        console.error('Error:', error)
-        reset()
-      }
-    }
-    init()
-  }, [])
-
   const reset = () => {
     setIsConnected(false)
     setAddress(undefined)
     setBeaconWallet(undefined)
     setTezos(undefined)
   }
+
+  // Push a resolved active account into React state (or reset if there is none).
+  const applyActiveAccount = (
+    account: { address: string } | null | undefined
+  ) => {
+    if (account && walletRef.current) {
+      setIsConnected(true)
+      setAddress(account.address)
+      setBeaconWallet(walletRef.current)
+      TzosInstance.setWalletProvider(walletRef.current)
+      setTezos(TzosInstance)
+    } else {
+      reset()
+    }
+  }
+
+  // Subscribe the provider's handler to a wallet client exactly once per client.
+  const subscribeWallet = (wallet: BeaconWallet | undefined) => {
+    if (wallet && !subscribedRef.current) {
+      wallet.client.subscribeToEvent(BeaconEvent.ACTIVE_ACCOUNT_SET, account =>
+        applyActiveAccount(account)
+      )
+      subscribedRef.current = true
+    }
+  }
+
+  // Fully destroy the current client (wiping all beacon:* storage + transport
+  // state), rebuild a fresh one, re-subscribe and return to a disconnected UI.
+  const hardReset = async () => {
+    try {
+      subscribedRef.current = false
+      walletRef.current = await resetBeaconWallet()
+      subscribeWallet(walletRef.current)
+    } catch (error) {
+      console.warn('[beacon] hard reset failed', error)
+    }
+    reset()
+  }
+
+  // On mount, sync active account and set provider
+  useEffect(() => {
+    const init = async () => {
+      try {
+        const wallet = walletRef.current
+        subscribeWallet(wallet)
+        const activeAccount = await wallet?.client.getActiveAccount()
+        applyActiveAccount(activeAccount)
+      } catch (error) {
+        console.error('Error:', error)
+        reset()
+      }
+    }
+    init()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <ConnectionContext.Provider
@@ -114,11 +129,11 @@ export const ConnectionProvider = ({ children }: { children: any }) => {
             })
         },
         disconnect: async () => {
-          const wallet = walletRef.current
-          await wallet?.client.removeAllAccounts()
-          setAddress(undefined)
-          setIsConnected(false)
-          reset()
+          // `removeAllAccounts()` only cleared the account list and left the
+          // secret seed, peers and transport/matrix/walletconnect state behind
+          // in the browser. Fully destroy and rebuild so nothing stale is
+          // cached — this is what stops Safari from needing a site-data clear.
+          await hardReset()
         },
         address,
         isConnected,

--- a/providers/ConnectionProvider/index.tsx
+++ b/providers/ConnectionProvider/index.tsx
@@ -11,6 +11,7 @@ import { TezosToolkit } from '@tezos-x/octez.js'
 import {
   createBeaconWallet,
   resetBeaconWallet,
+  purgeBeaconStorage,
   Tezos as TzosInstance,
   requestBeaconPermissions
 } from './beacon'
@@ -21,6 +22,7 @@ import { BeaconEvent } from '@tezos-x/octez.connect-sdk'
 interface ConnectionContextType extends Partial<WalletApi> {
   connect: () => Promise<void>
   disconnect: () => Promise<void>
+  resetConnection: () => Promise<void>
   isConnected?: boolean
   Tezos?: TezosToolkit
   beaconWallet?: BeaconWallet
@@ -193,6 +195,13 @@ export const ConnectionProvider = ({ children }: { children: any }) => {
           // in the browser. Fully destroy and rebuild so nothing stale is
           // cached — this is what stops Safari from needing a site-data clear.
           await hardReset()
+        },
+        resetConnection: async () => {
+          // A lost/dead connection is treated like a fresh visit: purge every
+          // beacon store and reload to the connect screen. You are either
+          // connected or you are not — no stuck in-between state.
+          await purgeBeaconStorage()
+          if (typeof window !== 'undefined') window.location.href = '/'
         },
         address,
         isConnected,

--- a/providers/ConnectionProvider/index.tsx
+++ b/providers/ConnectionProvider/index.tsx
@@ -10,7 +10,6 @@ import { WalletApi } from './types'
 import { TezosToolkit } from '@tezos-x/octez.js'
 import {
   createBeaconWallet,
-  resetBeaconWallet,
   purgeBeaconStorage,
   hasBeaconPeer,
   Tezos as TzosInstance,
@@ -31,44 +30,6 @@ interface ConnectionContextType extends Partial<WalletApi> {
 
 const ConnectionContext = createContext<ConnectionContextType | null>(null)
 
-// A stale Beacon session (e.g. after Safari ITP evicts part of the store) makes
-// the transport hang forever with no rejection. Time-box those calls so we can
-// detect the hang and self-heal instead of leaving the user stuck.
-//
-// - INIT: getActiveAccount() is instant, but client.init() re-establishes the
-//   transport for a restored session and is where a dead peer hangs. A healthy
-//   session settles in well under a second, so a generous ceiling only ever
-//   elapses in the genuinely-broken case.
-// - CONNECT: requestPermissions() legitimately waits for the user to approve in
-//   their wallet, so this is a long backstop against a never-settling promise,
-//   not a UX deadline.
-const INIT_TIMEOUT_MS = 12_000
-const CONNECT_TIMEOUT_MS = 180_000
-
-class TimeoutError extends Error {}
-
-const withTimeout = <T,>(
-  promise: Promise<T>,
-  ms: number,
-  label: string
-): Promise<T> =>
-  new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new TimeoutError(`${label} timed out after ${ms}ms`)),
-      ms
-    )
-    promise.then(
-      value => {
-        clearTimeout(timer)
-        resolve(value)
-      },
-      error => {
-        clearTimeout(timer)
-        reject(error)
-      }
-    )
-  })
-
 export const ConnectionProvider = ({ children }: { children: any }) => {
   const [address, setAddress] = useState<string | undefined>(undefined)
   const [Tezos, setTezos] = useState<TezosToolkit | undefined>(undefined)
@@ -78,6 +39,7 @@ export const ConnectionProvider = ({ children }: { children: any }) => {
   )
   const walletRef = useRef<BeaconWallet | undefined>(undefined)
   const subscribedRef = useRef<boolean>(false)
+  const initRanRef = useRef<boolean>(false)
   if (typeof window !== 'undefined' && !walletRef.current) {
     walletRef.current = createBeaconWallet()
   }
@@ -114,21 +76,29 @@ export const ConnectionProvider = ({ children }: { children: any }) => {
     }
   }
 
-  // Fully destroy the current client (wiping all beacon:* storage + transport
-  // state), rebuild a fresh one, re-subscribe and return to a disconnected UI.
-  const hardReset = async () => {
+  // "Fresh visit": the single way we ever drop to a disconnected state. We do
+  // NOT destroy-and-rebuild the client in place — that races with the client's
+  // own async init (and doubly so under React StrictMode's double-invoked mount
+  // effect) and leaves the transport wired to a dead instance, so the next
+  // connect gets no answer from the wallet. Instead we purge every beacon store
+  // and reload: the reloaded page constructs exactly one clean client.
+  const freshVisit = async (notifyWallet = false) => {
     try {
-      subscribedRef.current = false
-      walletRef.current = await resetBeaconWallet()
-      subscribeWallet(walletRef.current)
+      // Best-effort: let the wallet know we're disconnecting. Never rebuild.
+      if (notifyWallet) await walletRef.current?.disconnect()
     } catch (error) {
-      console.warn('[beacon] hard reset failed', error)
+      console.warn('[beacon] teardown during reset failed', error)
     }
-    reset()
+    await purgeBeaconStorage()
+    if (typeof window !== 'undefined') window.location.href = '/'
   }
 
-  // On mount, sync active account and set provider
+  // On mount, restore the active account (or reset)
   useEffect(() => {
+    // Guard against StrictMode's double-invoked mount effect (dev).
+    if (initRanRef.current) return
+    initRanRef.current = true
+
     const init = async () => {
       const wallet = walletRef.current
       subscribeWallet(wallet)
@@ -143,25 +113,17 @@ export const ConnectionProvider = ({ children }: { children: any }) => {
 
       // A restored account with no paired peer means the transport session was
       // evicted (classic Safari ITP): the account survives but the connection
-      // is dead. Deterministically treat that as disconnected — a fresh visit —
-      // instead of trusting the stale account.
+      // is dead. Treat it as a fresh visit rather than trusting a dead account.
       if (!hasBeaconPeer()) {
-        console.warn('[beacon] active account has no peer, resetting to connect')
-        await hardReset()
+        console.warn('[beacon] active account has no peer; resetting to connect')
+        await freshVisit()
         return
       }
 
-      // Peer present, so the session should be live. Verify the transport can
-      // actually be re-established before trusting it; if init() hangs or
-      // throws, self-heal by wiping the poisoned state rather than making the
-      // user clear site data by hand.
-      try {
-        await withTimeout(wallet.client.init(), INIT_TIMEOUT_MS, 'client.init')
-        applyActiveAccount(activeAccount)
-      } catch (error) {
-        console.error('[beacon] stale session detected on init, resetting', error)
-        await hardReset()
-      }
+      // Account + peer present: trust it. If the transport turns out to be dead,
+      // the first wallet operation detects it and drops to a fresh visit
+      // (see components/Operations/operations.ts + resetConnection).
+      applyActiveAccount(activeAccount)
     }
     init()
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -175,42 +137,36 @@ export const ConnectionProvider = ({ children }: { children: any }) => {
           if (!wallet) {
             throw new Error('Wallet not initialized')
           }
-          try {
-            const response = await withTimeout(
-              requestBeaconPermissions(wallet),
-              CONNECT_TIMEOUT_MS,
-              'requestPermissions'
-            )
-            setAddress(response.address)
-            setIsConnected(true)
-            setBeaconWallet(wallet)
-            TzosInstance.setWalletProvider(wallet)
-            setTezos(TzosInstance)
-            trackGAEvent(GAAction.CONNECT_SUCCESS, GACategory.WALLET_SUCCESS)
-          } catch (error) {
-            // A failed or hung permission request usually means a poisoned
-            // transport. Wipe it so the next attempt starts from a clean
-            // client instead of retrying against the same broken state.
-            trackGAEvent(GAAction.CONNECT_ERROR, GACategory.WALLET_ERROR)
-            await hardReset()
-            throw new Error(
-              'Error connecting to wallet, please try again later'
-            )
-          }
+          return await requestBeaconPermissions(wallet)
+            .then(response => {
+              setAddress(response.address)
+              setIsConnected(true)
+              setBeaconWallet(wallet)
+              TzosInstance.setWalletProvider(wallet)
+              setTezos(TzosInstance)
+              trackGAEvent(GAAction.CONNECT_SUCCESS, GACategory.WALLET_SUCCESS)
+            })
+            .catch(() => {
+              // Just reset UI state — do NOT tear down/rebuild the client, or
+              // the next attempt connects against a broken instance.
+              reset()
+              trackGAEvent(GAAction.CONNECT_ERROR, GACategory.WALLET_ERROR)
+              throw new Error(
+                'Error connecting to wallet, please try again later'
+              )
+            })
         },
         disconnect: async () => {
-          // `removeAllAccounts()` only cleared the account list and left the
-          // secret seed, peers and transport/matrix/walletconnect state behind
-          // in the browser. Fully destroy and rebuild so nothing stale is
-          // cached — this is what stops Safari from needing a site-data clear.
-          await hardReset()
+          // Full teardown as a fresh visit: notify the wallet, purge every
+          // beacon store (main + transport namespaces + IndexedDB), then reload
+          // to the connect screen. This is what stops Safari from ever needing a
+          // manual "clear site data".
+          await freshVisit(true)
         },
         resetConnection: async () => {
-          // A lost/dead connection is treated like a fresh visit: purge every
-          // beacon store and reload to the connect screen. You are either
-          // connected or you are not — no stuck in-between state.
-          await purgeBeaconStorage()
-          if (typeof window !== 'undefined') window.location.href = '/'
+          // A lost/dead connection is treated exactly like a disconnect: fresh
+          // visit. You are either connected or you are not.
+          await freshVisit(false)
         },
         address,
         isConnected,

--- a/providers/ConnectionProvider/index.tsx
+++ b/providers/ConnectionProvider/index.tsx
@@ -76,19 +76,16 @@ export const ConnectionProvider = ({ children }: { children: any }) => {
     }
   }
 
-  // "Fresh visit": the single way we ever drop to a disconnected state. We do
-  // NOT destroy-and-rebuild the client in place — that races with the client's
-  // own async init (and doubly so under React StrictMode's double-invoked mount
-  // effect) and leaves the transport wired to a dead instance, so the next
-  // connect gets no answer from the wallet. Instead we purge every beacon store
-  // and reload: the reloaded page constructs exactly one clean client.
-  const freshVisit = async (notifyWallet = false) => {
-    try {
-      // Best-effort: let the wallet know we're disconnecting. Never rebuild.
-      if (notifyWallet) await walletRef.current?.disconnect()
-    } catch (error) {
-      console.warn('[beacon] teardown during reset failed', error)
-    }
+  // "Fresh visit": the single way we ever drop to a disconnected state. Purge
+  // every beacon store and reload — the reloaded page constructs exactly one
+  // clean client. We deliberately do NOT call the SDK's destroy() here:
+  //  - destroy-and-rebuild in place races with the client's async init (doubly
+  //    so under StrictMode's double-invoked mount effect) and leaves the next
+  //    connect with no answer from the wallet;
+  //  - destroy() also stops the Matrix transport mid-sync, which rejects with a
+  //    benign "Syncing stopped manually" error that surfaces in the dev overlay.
+  // The page reload tears everything down cleanly instead.
+  const freshVisit = async () => {
     await purgeBeaconStorage()
     if (typeof window !== 'undefined') window.location.href = '/'
   }
@@ -157,16 +154,15 @@ export const ConnectionProvider = ({ children }: { children: any }) => {
             })
         },
         disconnect: async () => {
-          // Full teardown as a fresh visit: notify the wallet, purge every
-          // beacon store (main + transport namespaces + IndexedDB), then reload
-          // to the connect screen. This is what stops Safari from ever needing a
-          // manual "clear site data".
-          await freshVisit(true)
+          // Fresh visit: purge every beacon store (main + transport namespaces
+          // + IndexedDB) and reload to the connect screen. This is what stops
+          // Safari from ever needing a manual "clear site data".
+          await freshVisit()
         },
         resetConnection: async () => {
           // A lost/dead connection is treated exactly like a disconnect: fresh
           // visit. You are either connected or you are not.
-          await freshVisit(false)
+          await freshVisit()
         },
         address,
         isConnected,

--- a/utils/beaconDebug.ts
+++ b/utils/beaconDebug.ts
@@ -1,0 +1,132 @@
+/**
+ * Manual-QA helpers for reproducing the Safari "stale Beacon connection"
+ * failure without waiting days for ITP to evict storage on its own.
+ *
+ * None of this is used by the app at runtime — it only backs the gated
+ * BeaconDebugPanel so the fixes in ConnectionProvider can be exercised by hand.
+ *
+ * Beacon persists its state under `beacon:*` keys in localStorage (the SDK may
+ * add an instance prefix, so we match by substring), and the WalletConnect
+ * transport keeps its session in an IndexedDB database.
+ */
+
+const WALLETCONNECT_DB_NAMES = ['WALLET_CONNECT_V2_INDEXED_DB']
+
+// Substrings that identify transport / peer / session state — the parts Safari
+// ITP tends to evict independently, leaving an account pointing at a dead
+// transport. Identity + account state (seed, accounts, active-account,
+// permissions) is deliberately NOT matched so the app still believes it is
+// connected on the next load.
+const TRANSPORT_KEY_HINTS = [
+  'peers',
+  'matrix',
+  'walletconnect',
+  'wc-init',
+  'last-error'
+]
+
+const isBeaconKey = (key: string) => key.toLowerCase().includes('beacon:')
+
+export interface StorageEntry {
+  key: string
+  size: number
+  preview: string
+}
+
+export const listBeaconStorage = (): StorageEntry[] => {
+  if (typeof window === 'undefined') return []
+  const entries: StorageEntry[] = []
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (!key || !isBeaconKey(key)) continue
+    const value = localStorage.getItem(key) ?? ''
+    entries.push({
+      key,
+      size: value.length,
+      preview: value.length > 80 ? `${value.slice(0, 80)}…` : value
+    })
+  }
+  return entries.sort((a, b) => a.key.localeCompare(b.key))
+}
+
+export const listIndexedDbDatabases = async (): Promise<string[]> => {
+  if (typeof window === 'undefined' || !window.indexedDB) return []
+  const factory = window.indexedDB as IDBFactory & {
+    databases?: () => Promise<{ name?: string }[]>
+  }
+  if (typeof factory.databases === 'function') {
+    try {
+      const dbs = await factory.databases()
+      return dbs.map(d => d.name ?? '(unnamed)').filter(Boolean)
+    } catch {
+      // fall through to the known-names list below
+    }
+  }
+  return [...WALLETCONNECT_DB_NAMES]
+}
+
+const deleteIndexedDb = (name: string): Promise<void> =>
+  new Promise(resolve => {
+    if (typeof window === 'undefined' || !window.indexedDB) return resolve()
+    const request = window.indexedDB.deleteDatabase(name)
+    request.onsuccess = () => resolve()
+    request.onerror = () => resolve()
+    request.onblocked = () => resolve()
+  })
+
+export const deleteWalletConnectIndexedDb = async (): Promise<string[]> => {
+  const existing = await listIndexedDbDatabases()
+  const targets = existing.filter(
+    name => name && name.toLowerCase().includes('wallet_connect')
+  )
+  const toDelete = targets.length ? targets : WALLETCONNECT_DB_NAMES
+  await Promise.all(toDelete.map(deleteIndexedDb))
+  return toDelete
+}
+
+export interface SimulationResult {
+  removedKeys: string[]
+  keptKeys: string[]
+  removedDatabases: string[]
+}
+
+/**
+ * Simulate Safari ITP evicting the transport half of the Beacon store while the
+ * account identity survives — the exact shape that leaves the app stuck
+ * "connected" against a dead transport.
+ */
+export const simulateItpEviction = async (): Promise<SimulationResult> => {
+  const removedKeys: string[] = []
+  const keptKeys: string[] = []
+  if (typeof window !== 'undefined') {
+    for (const { key } of listBeaconStorage()) {
+      const isTransport = TRANSPORT_KEY_HINTS.some(hint =>
+        key.toLowerCase().includes(hint)
+      )
+      if (isTransport) {
+        localStorage.removeItem(key)
+        removedKeys.push(key)
+      } else {
+        keptKeys.push(key)
+      }
+    }
+  }
+  const removedDatabases = await deleteWalletConnectIndexedDb()
+  return { removedKeys, keptKeys, removedDatabases }
+}
+
+/**
+ * Wipe everything Beacon-related — the equivalent of a manual "clear site data"
+ * for this origin. Useful as a clean baseline between tests.
+ */
+export const clearAllBeaconStorage = async (): Promise<SimulationResult> => {
+  const removedKeys: string[] = []
+  if (typeof window !== 'undefined') {
+    for (const { key } of listBeaconStorage()) {
+      localStorage.removeItem(key)
+      removedKeys.push(key)
+    }
+  }
+  const removedDatabases = await deleteWalletConnectIndexedDb()
+  return { removedKeys, keptKeys: [], removedDatabases }
+}

--- a/utils/beaconDebug.ts
+++ b/utils/beaconDebug.ts
@@ -18,10 +18,28 @@ const BEACON_IDB_HINTS = ['beacon', 'wallet_connect']
 
 const isBeaconKey = (key: string) => key.toLowerCase().includes('beacon:')
 
-// A key belongs to the main client if it starts with `beacon:`; anything that
-// contains `beacon:` behind a prefix (`P2P-`, `WALLET-`, …) is transport-scoped.
-const isTransportScopedKey = (key: string) =>
-  isBeaconKey(key) && !key.toLowerCase().startsWith('beacon:')
+// Substrings that identify transport / peer / session state, independent of any
+// instance prefix. Deleting these while keeping the account identity keys
+// reproduces "connected but the transport is dead" — the shape a real
+// connection takes on this app (all keys are unprefixed `beacon:*`, e.g.
+// `beacon:postmessage-peers-dapp`, `beacon:sdk-matrix-preserved-state`).
+const TRANSPORT_KEY_HINTS = [
+  'peers',
+  'matrix',
+  'walletconnect',
+  'postmessage',
+  'wc-init',
+  'wc-2',
+  'wc_2'
+]
+
+// A key is transport state if it is behind an instance prefix (`P2P-`,
+// `WALLET-`) OR its name matches a transport/peer/session hint.
+const isTransportKey = (key: string) => {
+  const k = key.toLowerCase()
+  if (isBeaconKey(key) && !k.startsWith('beacon:')) return true
+  return TRANSPORT_KEY_HINTS.some(hint => k.includes(hint))
+}
 
 export interface StorageEntry {
   key: string
@@ -90,16 +108,18 @@ export interface SimulationResult {
 /**
  * Simulate Safari ITP evicting the transport half of the Beacon store while the
  * main account identity survives — the shape that leaves the app stuck
- * "connected" against a dead transport. Deletes the transport-scoped
- * (`P2P-`/`WALLET-`) localStorage keys and all beacon IndexedDB, keeping the
- * unprefixed `beacon:*` account keys so getActiveAccount() still returns.
+ * "connected" against a dead transport. Deletes every transport/peer/session
+ * key (peers, matrix, postmessage, walletconnect — at any prefix) and all
+ * beacon IndexedDB, keeping the account identity keys (accounts,
+ * active-account, seed, sdk_version, user-id) so getActiveAccount() still
+ * returns but no peer remains.
  */
 export const simulateItpEviction = async (): Promise<SimulationResult> => {
   const removedKeys: string[] = []
   const keptKeys: string[] = []
   if (typeof window !== 'undefined') {
     for (const { key } of listBeaconStorage()) {
-      if (isTransportScopedKey(key)) {
+      if (isTransportKey(key)) {
         localStorage.removeItem(key)
         removedKeys.push(key)
       } else {

--- a/utils/beaconDebug.ts
+++ b/utils/beaconDebug.ts
@@ -116,6 +116,20 @@ export const simulateItpEviction = async (): Promise<SimulationResult> => {
 }
 
 /**
+ * Reproduce the older-SDK crash where `beacon:last-selected-wallet` was stored
+ * as a bare string instead of an object. On reload, the unpatched app throws
+ * "Cannot create property 'name' on string ..." from updateStorageWallet();
+ * with the sanitizer in beacon.ts the bad key is removed and the app loads.
+ */
+export const simulateStaleLastSelectedWallet = (): string => {
+  const key = 'beacon:last-selected-wallet'
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(key, 'temple_chrome')
+  }
+  return key
+}
+
+/**
  * Wipe everything Beacon-related — the equivalent of a manual "clear site data"
  * for this origin. Useful as a clean baseline between tests.
  */

--- a/utils/beaconDebug.ts
+++ b/utils/beaconDebug.ts
@@ -79,22 +79,43 @@ export const listIndexedDbDatabases = async (): Promise<string[]> => {
   return []
 }
 
+// Known beacon IndexedDB names, used as a fallback when indexedDB.databases()
+// isn't available (older Safari and others) so the simulations still clear the
+// real Beacon DBs instead of silently no-op'ing.
+const KNOWN_BEACON_DB_NAMES = ['beacon', 'WALLET_CONNECT_V2_INDEXED_DB']
+
 const deleteIndexedDb = (name: string): Promise<void> =>
   new Promise(resolve => {
     if (typeof window === 'undefined' || !window.indexedDB) return resolve()
-    const request = window.indexedDB.deleteDatabase(name)
-    request.onsuccess = () => resolve()
-    request.onerror = () => resolve()
-    request.onblocked = () => resolve()
+    // Safari's deleteDatabase() can hang with no callback when a connection is
+    // still open. Time-box it so this helper stays best-effort and never blocks
+    // the QA panel.
+    const done = () => resolve()
+    const timer = setTimeout(done, 1500)
+    const finish = () => {
+      clearTimeout(timer)
+      resolve()
+    }
+    try {
+      const request = window.indexedDB.deleteDatabase(name)
+      request.onsuccess = finish
+      request.onerror = finish
+      request.onblocked = finish
+    } catch {
+      finish()
+    }
   })
 
 // Delete every beacon-related IndexedDB database and return the names actually
-// targeted (enumerated live, so the reported count matches reality).
+// targeted. Enumerates live where possible; falls back to known names when
+// indexedDB.databases() is unavailable.
 const deleteBeaconIndexedDbs = async (): Promise<string[]> => {
   const existing = await listIndexedDbDatabases()
-  const targets = existing.filter(name =>
-    BEACON_IDB_HINTS.some(hint => name.toLowerCase().includes(hint))
-  )
+  const targets = existing.length
+    ? existing.filter(name =>
+        BEACON_IDB_HINTS.some(hint => name.toLowerCase().includes(hint))
+      )
+    : KNOWN_BEACON_DB_NAMES
   await Promise.all(targets.map(deleteIndexedDb))
   return targets
 }

--- a/utils/beaconDebug.ts
+++ b/utils/beaconDebug.ts
@@ -5,27 +5,23 @@
  * None of this is used by the app at runtime — it only backs the gated
  * BeaconDebugPanel so the fixes in ConnectionProvider can be exercised by hand.
  *
- * Beacon persists its state under `beacon:*` keys in localStorage (the SDK may
- * add an instance prefix, so we match by substring), and the WalletConnect
- * transport keeps its session in an IndexedDB database.
+ * Beacon spreads its state across several stores:
+ *  - the main client:      localStorage keys `beacon:*`
+ *  - the P2P transport:    localStorage keys `P2P-beacon:*`
+ *  - the WalletConnect tx: localStorage keys `WALLET-beacon:*`
+ *  - IndexedDB:            `beacon` (metrics/bug-report) and, for a live WC
+ *                          session, `WALLET_CONNECT_V2_INDEXED_DB`
+ * We match by substring so any instance prefix is handled.
  */
 
-const WALLETCONNECT_DB_NAMES = ['WALLET_CONNECT_V2_INDEXED_DB']
-
-// Substrings that identify transport / peer / session state — the parts Safari
-// ITP tends to evict independently, leaving an account pointing at a dead
-// transport. Identity + account state (seed, accounts, active-account,
-// permissions) is deliberately NOT matched so the app still believes it is
-// connected on the next load.
-const TRANSPORT_KEY_HINTS = [
-  'peers',
-  'matrix',
-  'walletconnect',
-  'wc-init',
-  'last-error'
-]
+const BEACON_IDB_HINTS = ['beacon', 'wallet_connect']
 
 const isBeaconKey = (key: string) => key.toLowerCase().includes('beacon:')
+
+// A key belongs to the main client if it starts with `beacon:`; anything that
+// contains `beacon:` behind a prefix (`P2P-`, `WALLET-`, …) is transport-scoped.
+const isTransportScopedKey = (key: string) =>
+  isBeaconKey(key) && !key.toLowerCase().startsWith('beacon:')
 
 export interface StorageEntry {
   key: string
@@ -59,10 +55,10 @@ export const listIndexedDbDatabases = async (): Promise<string[]> => {
       const dbs = await factory.databases()
       return dbs.map(d => d.name ?? '(unnamed)').filter(Boolean)
     } catch {
-      // fall through to the known-names list below
+      // fall through
     }
   }
-  return [...WALLETCONNECT_DB_NAMES]
+  return []
 }
 
 const deleteIndexedDb = (name: string): Promise<void> =>
@@ -74,14 +70,15 @@ const deleteIndexedDb = (name: string): Promise<void> =>
     request.onblocked = () => resolve()
   })
 
-export const deleteWalletConnectIndexedDb = async (): Promise<string[]> => {
+// Delete every beacon-related IndexedDB database and return the names actually
+// targeted (enumerated live, so the reported count matches reality).
+const deleteBeaconIndexedDbs = async (): Promise<string[]> => {
   const existing = await listIndexedDbDatabases()
-  const targets = existing.filter(
-    name => name && name.toLowerCase().includes('wallet_connect')
+  const targets = existing.filter(name =>
+    BEACON_IDB_HINTS.some(hint => name.toLowerCase().includes(hint))
   )
-  const toDelete = targets.length ? targets : WALLETCONNECT_DB_NAMES
-  await Promise.all(toDelete.map(deleteIndexedDb))
-  return toDelete
+  await Promise.all(targets.map(deleteIndexedDb))
+  return targets
 }
 
 export interface SimulationResult {
@@ -92,18 +89,17 @@ export interface SimulationResult {
 
 /**
  * Simulate Safari ITP evicting the transport half of the Beacon store while the
- * account identity survives — the exact shape that leaves the app stuck
- * "connected" against a dead transport.
+ * main account identity survives — the shape that leaves the app stuck
+ * "connected" against a dead transport. Deletes the transport-scoped
+ * (`P2P-`/`WALLET-`) localStorage keys and all beacon IndexedDB, keeping the
+ * unprefixed `beacon:*` account keys so getActiveAccount() still returns.
  */
 export const simulateItpEviction = async (): Promise<SimulationResult> => {
   const removedKeys: string[] = []
   const keptKeys: string[] = []
   if (typeof window !== 'undefined') {
     for (const { key } of listBeaconStorage()) {
-      const isTransport = TRANSPORT_KEY_HINTS.some(hint =>
-        key.toLowerCase().includes(hint)
-      )
-      if (isTransport) {
+      if (isTransportScopedKey(key)) {
         localStorage.removeItem(key)
         removedKeys.push(key)
       } else {
@@ -111,7 +107,7 @@ export const simulateItpEviction = async (): Promise<SimulationResult> => {
       }
     }
   }
-  const removedDatabases = await deleteWalletConnectIndexedDb()
+  const removedDatabases = await deleteBeaconIndexedDbs()
   return { removedKeys, keptKeys, removedDatabases }
 }
 
@@ -141,6 +137,6 @@ export const clearAllBeaconStorage = async (): Promise<SimulationResult> => {
       removedKeys.push(key)
     }
   }
-  const removedDatabases = await deleteWalletConnectIndexedDb()
+  const removedDatabases = await deleteBeaconIndexedDbs()
   return { removedKeys, keptKeys: [], removedDatabases }
 }


### PR DESCRIPTION
## Why
- Beacon/octez wallet connection broke on Safari — only a manual "clear site data" recovered it.
- Cause: stale connection state (seed/peers/transport across localStorage `beacon:*` namespaces + IndexedDB) was never fully cleared; Safari ITP evicts parts of it → inconsistent state the SDK can't self-heal.

## What
- Disconnect now fully purges all beacon storage + reloads (was `removeAllAccounts()`, which left seed/peers/transport behind).
- Peerless/dead session detected on load → drop to a clean Connect state instead of trusting a stale account.
- Wallet operation on a dead connection → Connect state (binary: connected or not).
- Fix load crash from older-SDK `beacon:last-selected-wallet` string format ("Cannot create property 'name' on string").
- Safari: disconnect reload no longer blocks on IndexedDB `deleteDatabase` (hangs on open connections).
- Silence benign background rejections from unused transports (Matrix "Syncing stopped manually", WalletConnect "Proposal expired").
- Add env-gated debug/QA panel (`NEXT_PUBLIC_BEACON_DEBUG`, off by default) to reproduce ITP eviction / crashes.

## Test
- Connect / disconnect / reconnect clean in Chrome + Safari.
- Debug panel: "Simulate ITP eviction" → reload → Connect; dead-session operation → Connect.
- `yarn build` (static export) passes.
